### PR TITLE
Fix for Bannerlord v1.4.6 (June 2026 update)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,46 @@
+# Building Marry Anyone Updated
+
+## What you need
+- The game installed (this provides the reference assemblies via NuGet automatically, so you don't
+  strictly need the game files to compile — but you do to test).
+- A .NET SDK (8.0+). You do **not** need Visual Studio.
+
+### Getting a .NET SDK without installing Visual Studio
+You can use a portable SDK that lives in a folder and needs no admin rights:
+
+```powershell
+# Download the official installer script and extract an SDK into .\dotnetsdk
+Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile "dotnet-install.ps1"
+./dotnet-install.ps1 -Channel 8.0 -Quality GA -InstallDir ".\dotnetsdk" -NoPath
+```
+
+## Build
+```powershell
+.\dotnetsdk\dotnet.exe build MarryAnyone\MarryAnyone.csproj -c Release
+```
+The compiled mod appears at `MarryAnyone\bin\Release\net472\MarryAnyone.dll`.
+
+## Install / test the build
+Copy that `MarryAnyone.dll` over the one in your module's
+`bin\Win64_Shipping_Client\` folder:
+
+- Steam Workshop install:
+  `...\steamapps\workshop\content\261550\<workshop id>\bin\Win64_Shipping_Client\MarryAnyone.dll`
+- Manual install:
+  `...\Mount & Blade II Bannerlord\Modules\MarryAnyoneUpdated\bin\Win64_Shipping_Client\MarryAnyone.dll`
+
+(Back up the original DLL first.) Restart the game.
+
+## When a future Bannerlord update breaks it again
+The mod reaches into internal game methods by name (via Harmony/BUTR `AccessTools2`). Updates
+sometimes rename or remove those. To find what changed, point the project at the new reference
+assemblies:
+
+1. In `MarryAnyone\MarryAnyone.csproj`, bump `<GameVersion>` and the two
+   `Bannerlord.ReferenceAssemblies.Core` / `...SandBox` package versions to the new
+   `X.Y.Z.NNNNNN` (find the latest on nuget.org).
+2. Rebuild. Compile errors point at public-API breaks.
+3. For **internal** members accessed by string (they won't cause compile errors), a reliable trick
+   is to write a tiny reflection program that `ReflectionOnlyLoadFrom`s the game's
+   `TaleWorlds.CampaignSystem.dll` and lists the methods/fields you rely on, so you can see the new
+   names/signatures. See `CHANGELOG.md` for the v1.4.6 example (OnHeroesMarried -> OnBeforeHeroesMarried, etc.).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## [3.4.0] - Bannerlord v1.4.6 compatibility fix
+
+Fixes the crash and broken features introduced by the June 2026 Bannerlord update (game v1.4.6),
+which renamed/removed several internal APIs the mod accesses via reflection.
+
+### Fixed
+- **Crash when a marriage is finalized (e.g. taking a second wife).** The game renamed
+  `CampaignEventDispatcher.OnHeroesMarried(Hero, Hero, bool)` to `OnBeforeHeroesMarried`. The mod's
+  reflection delegate no longer resolved, throwing `MissingMethodException` on marriage.
+  (`MarryAnyone/Actions/MAMarriageAction.cs`)
+- **Incest / relation check.** `DefaultMarriageModel.DiscoverAncestors(Hero, int)` was removed; the
+  relation check now uses `AreHeroesRelated(Hero, Hero, int)`. (`MarryAnyone/Models/MAMarriageModel.cs`)
+- **Companion (townsperson) equipment adjustment.** `CompanionsCampaignBehavior.AdjustEquipment` was
+  renamed to `AdjustEquipments(Hero)`. (`MarryAnyone/Behaviors/MARomanceCampaignBehavior.cs`)
+- **Ex-spouse / polygamy cleanup.** `Hero.ExSpouses` is now a get-only property backed by the field
+  `_exSpouses`, whose type changed from `List<Hero>` to `MBList<Hero>`. The backing list is now
+  mutated in place. (`MarryAnyone/Helpers.cs`)
+
+### Changed
+- Retargeted the project to Bannerlord v1.4.6 reference assemblies
+  (`Bannerlord.ReferenceAssemblies.Core`/`SandBox` `1.4.6.115628`) and set `<GameVersion>1.4.6</GameVersion>`.
+- Added a NuGet `Microsoft.NETFramework.ReferenceAssemblies` reference so the project builds without a
+  locally installed .NET Framework 4.7.2 targeting pack.
+
+### Notes
+- Built against .NET Framework 4.7.2, C# 9.
+- All game API references were audited against the installed v1.4.6 assemblies; the four items above
+  were the only breaks.

--- a/MarryAnyone/Actions/MAMarriageAction.cs
+++ b/MarryAnyone/Actions/MAMarriageAction.cs
@@ -14,8 +14,9 @@ namespace MarryAnyone.Actions
         //private delegate void PlayerDefaultFactionDelegate(Campaign instance, Clan @value);
         //private static readonly PlayerDefaultFactionDelegate? PlayerDefaultFaction = AccessTools2.GetPropertySetterDelegate<PlayerDefaultFactionDelegate>(typeof(Campaign), "PlayerDefaultFaction");
 
-        private delegate void OnHeroesMarriedDelegate(CampaignEventDispatcher instance, Hero firstHero, Hero secondHero, bool showNotification);
-        private static readonly OnHeroesMarriedDelegate? _onHeroesMarried = AccessTools2.GetDelegate<OnHeroesMarriedDelegate>(typeof(CampaignEventDispatcher), "OnHeroesMarried", new Type[] { typeof(Hero), typeof(Hero), typeof(bool) });
+        // Bannerlord v1.4.6 renamed CampaignEventDispatcher.OnHeroesMarried -> OnBeforeHeroesMarried (same signature)
+        private delegate void OnBeforeHeroesMarriedDelegate(CampaignEventDispatcher instance, Hero firstHero, Hero secondHero, bool showNotification);
+        private static readonly OnBeforeHeroesMarriedDelegate? _onBeforeHeroesMarried = AccessTools2.GetDelegate<OnBeforeHeroesMarriedDelegate>(typeof(CampaignEventDispatcher), "OnBeforeHeroesMarried", new Type[] { typeof(Hero), typeof(Hero), typeof(bool) });
 
         // Appears to ultimately avoid disbanding parties and the like...
         // Never disband party for hero, do for everyone else...
@@ -211,7 +212,7 @@ namespace MarryAnyone.Actions
             EndAllCourtshipsPatch.EndAllCourtships(firstHero);
             EndAllCourtshipsPatch.EndAllCourtships(secondHero);
             ChangeRomanticStateAction.Apply(firstHero, secondHero, Romance.RomanceLevelEnum.Marriage);
-            _onHeroesMarried?.Invoke(CampaignEventDispatcher.Instance, firstHero, secondHero, showNotification);
+            _onBeforeHeroesMarried?.Invoke(CampaignEventDispatcher.Instance, firstHero, secondHero, showNotification);
         }
 
         public static void Apply(Hero firstHero, Hero secondHero, bool showNotification = true)

--- a/MarryAnyone/Behaviors/MARomanceCampaignBehavior.cs
+++ b/MarryAnyone/Behaviors/MARomanceCampaignBehavior.cs
@@ -77,8 +77,9 @@ namespace MarryAnyone.Behaviors
         private static readonly SetHeroStaticBodyPropertiesDelegate? SetHeroStaticBodyProperties = AccessTools2.GetPropertySetterDelegate<SetHeroStaticBodyPropertiesDelegate>(typeof(Hero), "StaticBodyProperties");
 
         /* Methods */
+        // Bannerlord v1.4.6 renamed CompanionsCampaignBehavior.AdjustEquipment -> AdjustEquipments(Hero)
         private delegate void CompanionAdjustEquipmentDelegate(CompanionsCampaignBehavior instance, Hero companion);
-        private static readonly CompanionAdjustEquipmentDelegate? CompanionAdjustEquipment = AccessTools2.GetDelegate<CompanionAdjustEquipmentDelegate>(typeof(CompanionsCampaignBehavior), "AdjustEquipment");
+        private static readonly CompanionAdjustEquipmentDelegate? CompanionAdjustEquipment = AccessTools2.GetDelegate<CompanionAdjustEquipmentDelegate>(typeof(CompanionsCampaignBehavior), "AdjustEquipments");
 
 
         protected void AddDialogs(CampaignGameStarter starter)

--- a/MarryAnyone/Helpers.cs
+++ b/MarryAnyone/Helpers.cs
@@ -11,9 +11,26 @@ namespace MarryAnyone
 {
     internal static class Helpers
     {
-        private static readonly AccessTools.FieldRef<Hero, MBReadOnlyList<Hero>>? ExSpouses = AccessTools2.FieldRefAccess<Hero, MBReadOnlyList<Hero>>("ExSpouses");
+        // Bannerlord v1.4.6: Hero.ExSpouses is now a get-only property (MBReadOnlyList<Hero>) backed by
+        // the field _exSpouses, whose type changed from List<Hero> to MBList<Hero>. There is no longer a
+        // separate ExSpouses backing field, so we mutate the _exSpouses list in place.
+        private static readonly AccessTools.FieldRef<Hero, MBList<Hero>>? _exSpouses = AccessTools2.FieldRefAccess<Hero, MBList<Hero>>("_exSpouses");
 
-        private static readonly AccessTools.FieldRef<Hero, List<Hero>>? _exSpouses = AccessTools2.FieldRefAccess<Hero, List<Hero>>("_exSpouses");
+        // Overwrite a hero's ex-spouse list in place so the ExSpouses property (which wraps this field) stays in sync.
+        private static void SetExSpouses(Hero hero, List<Hero> newList)
+        {
+            MBList<Hero> list = _exSpouses!(hero);
+            if (list is null)
+            {
+                list = new MBList<Hero>();
+                _exSpouses!(hero) = list;
+            }
+            list.Clear();
+            foreach (Hero h in newList)
+            {
+                list.Add(h);
+            }
+        }
 
         public enum RemoveExSpousesMode
         {
@@ -38,7 +55,7 @@ namespace MarryAnyone
 
         public static void RemoveExSpouses(Hero hero, RemoveExSpousesMode removalMode = RemoveExSpousesMode.Duplicates)
         {
-            if (_exSpouses is null || ExSpouses is null)
+            if (_exSpouses is null)
             {
                 return;
             }
@@ -79,8 +96,7 @@ namespace MarryAnyone
                         var theirExSpouses = _exSpouses(exSpouse)?.ToList() ?? new List<Hero>();
                         theirExSpouses.Remove(hero);
 
-                        _exSpouses(exSpouse) = theirExSpouses;
-                        ExSpouses(exSpouse) = new MBReadOnlyList<Hero>(theirExSpouses);
+                        SetExSpouses(exSpouse, theirExSpouses);
                     }
                 }
 
@@ -89,20 +105,19 @@ namespace MarryAnyone
                     exSpouses.Remove(ex);
             }
 
-            _exSpouses(hero) = exSpouses;
-            ExSpouses(hero) = new MBReadOnlyList<Hero>(exSpouses);
+            SetExSpouses(hero, exSpouses);
 
             Print($"Ex-spouses after cleanup: {exSpouses.Count}");
         }
 
         public static void CheatOnSpouse()
         {
-            if (_exSpouses is null || ExSpouses is null)
+            if (_exSpouses is null)
             {
                 return;
             }
-            List<Hero> _exSpousesList = _exSpouses(Hero.MainHero);
-            List<Hero> cheatedHeroes = _exSpousesList.Where(exSpouse => exSpouse.IsAlive).ToList();
+            MBList<Hero> _exSpousesList = _exSpouses(Hero.MainHero);
+            List<Hero> cheatedHeroes = _exSpousesList?.Where(exSpouse => exSpouse.IsAlive).ToList() ?? new List<Hero>();
 
             foreach (Hero cheatedHero in cheatedHeroes)
             {

--- a/MarryAnyone/MarryAnyone.csproj
+++ b/MarryAnyone/MarryAnyone.csproj
@@ -8,8 +8,8 @@
     <Nullable>enable</Nullable>
     <ModuleId>$(MSBuildProjectName)</ModuleId>
     <ModuleName>Marry Anyone</ModuleName>
-    <GameFolder>D:\SteamLibrary\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>
-    <GameVersion>1.3.15</GameVersion>
+    <GameFolder>C:\Program Files (x86)\Steam\steamapps\common\Mount &amp; Blade II Bannerlord</GameFolder>
+    <GameVersion>1.4.6</GameVersion>
   </PropertyGroup>
   
   <!-- Development Variables -->
@@ -28,9 +28,11 @@
     <PackageReference Include="Bannerlord.BuildResources" Version="1.1.0.129" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="Harmony.Extensions" Version="3.2.0.77" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="BUTR.Harmony.Analyzer" Version="1.0.1.50" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <!-- .NET Framework reference assemblies via NuGet (so no targeting pack install is required) -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <!-- Assembly Reference Metadata -->
-    <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.3.15.110062" PrivateAssets="All" />
-    <PackageReference Include="Bannerlord.ReferenceAssemblies.SandBox" Version="1.3.15.110062" PrivateAssets="All" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.Core" Version="1.4.6.115628" PrivateAssets="All" />
+    <PackageReference Include="Bannerlord.ReferenceAssemblies.SandBox" Version="1.4.6.115628" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup>

--- a/MarryAnyone/Models/MAMarriageModel.cs
+++ b/MarryAnyone/Models/MAMarriageModel.cs
@@ -10,8 +10,9 @@ namespace MarryAnyone.Models
 {
     internal sealed class MAMarriageModel : DefaultMarriageModel
     {
-        private delegate IEnumerable<Hero> DiscoverAncestorsDelegate(DefaultMarriageModel instance, Hero hero, int n);
-        private static readonly DiscoverAncestorsDelegate? DiscoverAncestors = AccessTools2.GetDelegate<DiscoverAncestorsDelegate>(typeof(DefaultMarriageModel), "DiscoverAncestors", new Type[] { typeof(Hero), typeof(int) });
+        // Bannerlord v1.4.6 removed DefaultMarriageModel.DiscoverAncestors; the incest/relation check is now AreHeroesRelated(first, second, ancestorDepth)
+        private delegate bool AreHeroesRelatedDelegate(DefaultMarriageModel instance, Hero firstHero, Hero secondHero, int ancestorDepth);
+        private static readonly AreHeroesRelatedDelegate? AreHeroesRelated = AccessTools2.GetDelegate<AreHeroesRelatedDelegate>(typeof(DefaultMarriageModel), "AreHeroesRelated", new Type[] { typeof(Hero), typeof(Hero), typeof(int) });
 
         private bool _mainHeroMarriage = false;
         private bool _mainHero = false;
@@ -64,9 +65,9 @@ namespace MarryAnyone.Models
 
             if (!settings.Incest)
             {
-                if (DiscoverAncestors != null)
+                if (AreHeroesRelated != null)
                 {
-                    if (DiscoverAncestors(this, firstHero, 3).Intersect(DiscoverAncestors(this, secondHero, 3)).Any())
+                    if (AreHeroesRelated(this, firstHero, secondHero, 3))
                     {
                         return false;
                     }


### PR DESCRIPTION
The June 2026 update (game v1.4.6) renamed/removed several internal APIs the mod
uses via reflection, causing a hard crash when a marriage is finalized (e.g. taking
a second wife) and silently breaking a few features. This PR restores compatibility.

Fixes:
- CampaignEventDispatcher.OnHeroesMarried → OnBeforeHeroesMarried  (crash on marriage)
- DefaultMarriageModel.DiscoverAncestors → AreHeroesRelated        (incest/relation check)
- CompanionsCampaignBehavior.AdjustEquipment → AdjustEquipments     (townsfolk equipment)
- Hero._exSpouses is now MBList<Hero>; ExSpouses is a get-only property (ex-spouse cleanup)

Also retargeted the project to the 1.4.6 reference assemblies (1.4.6.115628) and added
Microsoft.NETFramework.ReferenceAssemblies so it builds without a local targeting pack.

All reflection/patch targets were audited against the installed v1.4.6 assemblies;
these four were the only breaks. Tested in-game: marriage, second spouse, and skip-courtship
all work. See CHANGELOG.md for details.